### PR TITLE
Added commands to avoid error "Font ptmr8r not found”

### DIFF
--- a/beamers/Readme.txt
+++ b/beamers/Readme.txt
@@ -4,3 +4,7 @@ This guide is currently only valid for WINDOWS, but it does not deal with all pr
  "C:\Program Files (x86)\MiKTeX 2.9\tex\latex" (so that you will have your files in "C:\Program Files (x86)\MiKTeX 2.9\tex\latex\beamers") 
  
  2) Open MikTeX 2.9 Settings/Options as administrator -> General tab -> Click Refresh FNDB  (may also try clicking update formats)
+
+ 3) Open a command window (cdm.exe) and run the following commands:
+	updmap --admin
+	initexmf --mkmaps


### PR DESCRIPTION
Hi.

I was using your template for the subject TK8103 and found that you must run two commands to avoid an error when compiling the .tex files. I just updated the Readme.txt file inside the "beamers" folder.

Best,
Erick.